### PR TITLE
Add ability to globally pause or resume auto scrolling from an instance of JXBanner

### DIFF
--- a/JXBanner/Classes/Banner/Banner/JXBaseBanner.swift
+++ b/JXBanner/Classes/Banner/Banner/JXBaseBanner.swift
@@ -223,3 +223,14 @@ extension JXBaseBanner {
     }
     
 }
+
+// MARK: - global support for pausing and resume autoScrolling
+public extension JXBaseBanner {
+    func pauseAutoScrolling(){
+        self.pause()
+    }
+    
+    func resumeAutoScrolling() {
+        self.resume()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ Need to implement JXBannerTransformable agreement, modify UICollectionViewLayout
 * reuseIdentifier ---> Cell reuse identity. If you use multiple jxbanners in your app, please set different values to facilitate the differentiation
 * nib ---> The nib parameter assignment must be done when using the nib cell file !!!
 
+##### Pause or resume auto-scrolling
+```swift
+let banner = JXBanner(frame: .zero)
+
+// Pause
+banner.pauseAutoScrolling()
+
+// Resume
+banner.resumeAutoScrolling()
+```
+
 
 
 ---


### PR DESCRIPTION

Hi, I have added two methods which acts as a relay to call the internal pause  & resume autoscrolling methods. 
I needed this feature for our app, so I am making a PR just in case someone needs it too. 

Note: I have also updated README to include details on how to pause or resume. 
```swift
let banner = JXBanner(frame: .zero)
// Pause
banner.pauseAutoScrolling()
// Resume
banner.resumeAutoScrolling()

``` 